### PR TITLE
bugs fixed

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,7 +1,5 @@
 {
   "directory": "bower_components",
   "analytics": false,
-  "interactive": false,
-  "proxy": "http://proxy.lh.petrochina:8080",
-  "https-proxy": "http://proxy.lh.petrochina:8080"
+  "interactive": false
 }

--- a/app/styles/home.less
+++ b/app/styles/home.less
@@ -195,6 +195,10 @@ p {
 }
 
 #partner {
+    .row{
+            margin-left:0px;
+            margin-right:0px;
+        }
     p {
         margin: 40px auto;
         @media (max-width: 480px) {

--- a/app/templates/components/ebc-header.hbs
+++ b/app/templates/components/ebc-header.hbs
@@ -1,19 +1,19 @@
-<nav id="menu" class="navbar navbar-default navbar-fixed-top" role="navigation">
+{{#bs-navbar position="fixed-top"}}
   <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse-1">
+      {{#bs-navbar-toggle}}
                 <span class="sr-only">Toggle navigation</span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
-            </button>
+      {{/bs-navbar-toggle}}
       <a title="Ebookchain" href="/" class="navbar-brand">
         <img src="/icons/ebookchain-logo-40x40.png" class="img-responsive">
       </a>
     </div>
 
-    <div class="navbar-collapse collapse" id="navbar-collapse-1">
-      <ul class="nav navbar-nav navbar-right">
+    {{#bs-navbar-content}}
+      {{#bs-navbar-nav class="navbar-right"}}
         <li>{{#link-to 'home'}} {{t "header.nav.home"}} {{/link-to}}</li>
         <li><a href="http://blog.ebookchain.org/products/">{{t "header.nav.products"}}</a></li>
         <li><a href="http://blog.ebookchain.org/books/">{{t "header.nav.ebooks"}}</a></li>
@@ -27,7 +27,7 @@
            </a>
         </li>
         <li>{{language-select}}</li>
-      </ul>
-    </div>
+      {{/bs-navbar-nav}}
+    {{/bs-navbar-content}}
   </div>
-</nav>
+{{/bs-navbar}}

--- a/doc/development.md
+++ b/doc/development.md
@@ -20,7 +20,7 @@ You will need the following things properly installed on your computer.
 ## Running / Development
 
 * `ember server`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your app at [http://localhost:4000](http://localhost:4000).
 
 ### Code Generators
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "loader.js": "^4.0.1"
   },
   "dependencies": {
-    "ember-bootstrap": "^0.7.0"
+    "ember-bootstrap": "^0.11.0"
   }
 }


### PR DESCRIPTION
1. bower安装错误
       修改： 把 bower 配置文件 bowerrc 中的代理设置删除

2. 文档中的端口与源码不一致：
     修改：安装文档中端口4200改为4000


3. 响应式导航栏无法展开
   
    原因：ember-bootstrap 与 bootstrap 冲突，在高版本中已删除data-toggle属性，
    https://github.com/kaliber5/ember-bootstrap/issues/115

    修改：
        升级ember-bootstrap版本；
        修改ebc-header代码，如下：
        
4. 下方出现滚动条，右侧空白溢出
    原因：partner中的.row的左右margin为-15
    修改：将.row的左右margin设为0。